### PR TITLE
ECOSYS-174 Removed unecessary dependency on omniauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+# IDEs
+.idea/
+.vscode/
+vendor/

--- a/lib/omniauth/azure_oauth2/version.rb
+++ b/lib/omniauth/azure_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module AzureOauth2
-    VERSION = "0.0.10"
+    VERSION = "0.0.11"
   end
 end

--- a/omniauth-azure-oauth2.gemspec
+++ b/omniauth-azure-oauth2.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 
   gem.add_development_dependency 'rspec', '~> 2.14'
-  gem.add_development_dependency 'rake', '~> 13.0'
+  gem.add_development_dependency 'rake'
 end

--- a/omniauth-azure-oauth2.gemspec
+++ b/omniauth-azure-oauth2.gemspec
@@ -16,11 +16,10 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::AzureOauth2::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'jwt', ['>= 1.0', '< 3.0']
 
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 
-  gem.add_development_dependency 'rspec', '>= 2.14.0'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rspec', '~> 2.14'
+  gem.add_development_dependency 'rake', '~> 13.0'
 end


### PR DESCRIPTION
This gem is no longer supported by owner and have dependency on omniauth ~> 1 but we need to update omniauth to latest where we use this gem (e.g. galaxy). So I just removed this dependency here because it's actually uneccesary so we can easily update omniauth